### PR TITLE
Add Guix build instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ $ make
 ```
 5. Locate `nuklear.so` in the build folder.
 
+#### Via GNU Guix
+
+LÖVE-Nuklear is also available as a [Guix](http://guix.gnu.org/) package, and can thus be directly downloaded and built via:
+```
+$ guix package --install love-nuklear
+```
+
 ### Compiling with CMake and MinGW on Windows
 
 1. Install [CMake](https://cmake.org/download/) and [MinGW](http://mingw.org/) or [MinGW-w64](https://mingw-w64.org/doku.php).


### PR DESCRIPTION
Hey Kevin, that little Guix packaging experiment I mentioned came through, so your package is now part of the Guix package repo :smile: So I thought it'd be good to add this note into your README

This is [the patch](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=38548) if you'd like to check it out.