### PR TITLE
Attempt to add support for 9-slice

### DIFF
--- a/example/skin.lua
+++ b/example/skin.lua
@@ -6,9 +6,13 @@ local checkboxTexture = love.graphics.newImage 'skin/checkbox.png'
 local checkboxOff = {checkboxTexture, love.graphics.newQuad(0, 0, 51, 55, 58, 115)}
 local checkboxOn = {checkboxTexture, love.graphics.newQuad(0, 55, 58, 60, 58, 115)}
 local buttonTexture = love.graphics.newImage 'skin/button.png'
-local buttonNormal = {buttonTexture, love.graphics.newQuad(0, 0, 69, 52, 69, 156)}
 local buttonActive = {buttonTexture, love.graphics.newQuad(0, 52, 69, 52, 69, 156)}
 local buttonHover = {buttonTexture, love.graphics.newQuad(0, 104, 69, 52, 69, 156)}
+
+
+-- last 4 args are 9-patch t/l/b/r. These are encoded as the number of pixels from the corresponding
+-- edge (e.g. "4" for "r" means "4 pixels from the right edge", or w - 4).
+local buttonNormal = {buttonTexture, love.graphics.newQuad(0, 0, 69, 52, 69, 156), 25, 12, 22, 12}
 
 local style = {
 	['text'] = {

--- a/src/nuklear_love.c
+++ b/src/nuklear_love.c
@@ -3681,7 +3681,26 @@ static int nk_love_style_push_item(lua_State *L, struct nk_style_item *field)
 		}
 		item.type = NK_STYLE_ITEM_COLOR;
 		item.data.color = nk_love_checkcolor(L, -1);
-	} else {
+	} else if (lua_istable(L, -1) && lua_objlen(L, -1) == 6) {
+		item.type = NK_STYLE_ITEM_NINE_SLICE;
+
+		int index = lua_gettop(L);
+		nk_love_checkImage(L, -1, &item.data.slice.img);
+
+		lua_rawgeti(L, index, 3);
+		item.data.slice.l = lua_tointeger(L, -1);
+
+		lua_rawgeti(L, index, 4);
+		item.data.slice.t = lua_tointeger(L, -1);
+
+		lua_rawgeti(L, index, 5);
+		item.data.slice.r = lua_tointeger(L, -1);
+
+		lua_rawgeti(L, index, 6);
+		item.data.slice.b = lua_tointeger(L, -1);
+		lua_pop(L, 4);
+	}
+	else {
 		item.type = NK_STYLE_ITEM_IMAGE;
 		nk_love_checkImage(L, -1, &item.data.image);
 	}


### PR DESCRIPTION
Hello! I'm trying to add support for nuklear's [9-slice](https://en.wikipedia.org/wiki/9-slice_scaling) rendering to love-nuklear. If you aren't familiar, it's a way to specify a texture for use as a button / window / whatever in a manner that avoids scaling artifacts at the corners and edges. 

I've done a (quick-and-dirty for now) modification of `nk_love_style_push_item` to additionally accept 9-slice args (`{image, quad, top, left, bottom, right}`) in addition to its current support for colors and images. Mechanically things are working, but it renders very oddly (see below). There are enough unknowns that I'm having a hard time debugging:

* The lua API is fairly new to me (but I think I have this right)
* nuklear itself is new to me and the docs aren't great, although after studying the source and the 9-slice PR in its repo I think I have the arguments correct (see the comment in `skin.lua`)
* I could be misusing some of `nuklear-love`'s abstractions

I've modified the "skin" example as a test -- I'm trying to render the normal button using a 9-slice. What I get is below; note the odd tiling effect in the button rendering.

Anywhoo, I'm going to continue to debug but I thought I'd throw this up in case more experienced eyes can see the thing that I'm doing wrong.


![Screenshot from 2023-09-05 18-37-02](https://github.com/keharriso/love-nuklear/assets/1692535/3ed36f2b-7156-46c7-a41d-5c759a3e6da3)
